### PR TITLE
Updated v0.1.6 - Control calendar files with no tasks

### DIFF
--- a/polical/SimpleIcsToCSV.py
+++ b/polical/SimpleIcsToCSV.py
@@ -8,6 +8,8 @@ import logging
 logging.basicConfig(filename=configuration.get_file_location('Running.log'),level=logging.INFO, format='%(asctime)s:%(levelname)s:%(message)s')
 
 def addEvent(header, filename):
+    if header == None:
+        return None
     f = open(configuration.get_file_location(filename), "r", encoding='utf-8')
     f2 = open(configuration.get_file_location("calendar.csv"), "w+")
     f1 = f.readlines()
@@ -151,7 +153,10 @@ def findHeader(icsCal):
     if os.path.exists(filename):
         os.remove(filename)
     # Get the header with the most number of tags
-    return max(listHeaders, key=len)
+    if len(listHeaders) > 1:
+        return max(listHeaders, key=len)
+    else:
+        return None
 
 
 def main(argv):

--- a/polical/TareasCSVToBD.py
+++ b/polical/TareasCSVToBD.py
@@ -9,28 +9,31 @@ logging.basicConfig(filename=configuration.get_file_location('Running.log'),leve
 
 
 def LoadCSVTasktoDB(username, user_dict):
-    with open(configuration.get_file_location('calendar.csv')) as csv_file:
-        logging.info("CSV abierto.")
-        csv_reader = csv.reader(csv_file, delimiter=';')
-        line_count = 0
-        for row in csv_reader:
-            if line_count == 0:
-                line_count += 1
-            elif len(row) > 9 and not line_count == 0:
-                # print(len(row))
-                create_subject.create(
-                    Get_Subject_Name_From_CSV(row[9]),row[2], user_dict)
-                sbjID = connectSQLite.getSubjectID(
-                    Get_Subject_Name_From_CSV(row[9]))
-                # print(row[0])
-                # Siempre se extraera la fecha aun cuando pueda tener un
-                # formato YMDTXXX
-                task = TareaClass.Tarea(
-                    row[1], row[2], row[3], datetime.strptime(row[7][0:8], '%Y%m%d'), sbjID)
-                sql = connectSQLite.saveTask(task, username)
-                # print("Las tareas nuevas se agregaron a la BD")
-                logging.info("Las tareas nuevas se agregaron a la BD")
-                sql.connection.close()
+    try:
+        with open(configuration.get_file_location('calendar.csv')) as csv_file:
+            logging.info("CSV abierto.")
+            csv_reader = csv.reader(csv_file, delimiter=';')
+            line_count = 0
+            for row in csv_reader:
+                if line_count == 0:
+                    line_count += 1
+                elif len(row) > 9 and not line_count == 0:
+                    # print(len(row))
+                    create_subject.create(
+                        Get_Subject_Name_From_CSV(row[9]),row[2], user_dict)
+                    sbjID = connectSQLite.getSubjectID(
+                        Get_Subject_Name_From_CSV(row[9]))
+                    # print(row[0])
+                    # Siempre se extraera la fecha aun cuando pueda tener un
+                    # formato YMDTXXX
+                    task = TareaClass.Tarea(
+                        row[1], row[2], row[3], datetime.strptime(row[7][0:8], '%Y%m%d'), sbjID)
+                    sql = connectSQLite.saveTask(task, username)
+                    # print("Las tareas nuevas se agregaron a la BD")
+                    logging.info("Las tareas nuevas se agregaron a la BD")
+                    sql.connection.close()
+    except (FileNotFoundError):
+        print("!FNF")
 
 
 def Get_Subject_Name_From_CSV(full_subject_name):


### PR DESCRIPTION
Some students can have files with no tasks and the app was not prepared to that, so in this version if detects a file like that sends a warning and the script continues.